### PR TITLE
Add one-line deployment and HTTP Authentication to Rails SP.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '4.2.6'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+gem 'pg'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
@@ -28,4 +27,8 @@ end
 
 group :test do
   gem 'codeclimate-test-reporter', require: nil
+end
+
+group :production do
+  gem 'rails_12factor'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
       ruby-saml (~> 1.3)
     parser (2.3.1.2)
       ast (~> 2.2)
+    pg (0.18.4)
     pkg-config (1.1.7)
     powerpack (0.1.1)
     rack (1.6.4)
@@ -106,6 +107,11 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.5)
+    rails_stdout_logging (0.0.5)
     railties (4.2.6)
       actionpack (= 4.2.6)
       activesupport (= 4.2.6)
@@ -158,7 +164,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.11)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -182,11 +187,12 @@ DEPENDENCIES
   byebug
   codeclimate-test-reporter
   omniauth-saml
+  pg
   rails (= 4.2.6)
+  rails_12factor
   rspec-rails (~> 3.4)
   rubocop
   sass-rails (~> 5.0)
-  sqlite3
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ May also function as reference Service Provider implementation.
 ### Setup
 
     $ bundle install
+    
+### Setup (on cloud.gov)
+    $ cf target -o consumer-identity -s [dev or demo]
+    $ cf create-service rds shared-psql id-sp-rails_production-[dev or demo]
+    $ cf bind-service identity-sp-rails-[dev or demo] mid-sp-rails_production-[dev or demo]
+    $ cf restage identity-sp-rails-[dev or demo]
+    
+    then
+    $ cf push -f task_manifest.yml (file needs to be edited for -dev)
+    $ cf delete task-runner
+    
+    (see, for reference https://docs.cloud.gov/apps/databases/ and https://docs.cloud.gov/getting-started/one-off-tasks/)
 
 ### Testing
 
@@ -19,7 +31,12 @@ May also function as reference Service Provider implementation.
 
 ### Running
 
-    $ bundle exec rails s
+    $ SAML_ENV=local bundle exec rails s
+    
+### Running (on cloud.gov)
+    
+    $ bin/cloud_deploy [dev or demo]
+    (Note: You'll need to be logged into cloud.gov first)
 
 ### Generating a new key + self-signed cert
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,9 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  if Rails.env.production?
+    http_basic_authenticate_with name: Rails.application.secrets.http_auth_username,
+                                 password: Rails.application.secrets.http_auth_password
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,6 @@ class SessionsController < ApplicationController
 
   def create
     user = User.from_omniauth(request.env['omniauth.auth'])
-
     session[:user_id] = user.id
 
     redirect_to(
@@ -13,8 +12,8 @@ class SessionsController < ApplicationController
   end
 
   def failure
-    flash[:error] = t('omniauth_callbacks.failure', reason: failure_message)
-    redirect_to root_url
+    flash[:alert] = t('omniauth_callbacks.failure', reason: failure_message)
+    redirect_to failure_url
   end
 
   private

--- a/app/views/home/failure.html.erb
+++ b/app/views/home/failure.html.erb
@@ -1,0 +1,18 @@
+<div class="py1 mb3 center">
+  <h2>Authentication from Login.gov was not successful! :(</h2>
+</div>
+<div class="clearfix py3 mxn1">
+  <% (0..7).each do |i| %>
+      <div class="sm-col sm-col-6 px1">
+        <div class="p2 mb2 bg-white rounded">
+          <div class="p1 mb1 bg-darken-1 col-7"></div>
+          <div class="p1 mb1 bg-darken-1 col-10"></div>
+          <div class="p1 mb1 bg-darken-1 col-5"></div>
+          <div class="p1 mb1 bg-darken-1 col-8"></div>
+          <div class="p1 mb1 bg-darken-1 col-6"></div>
+          <div class="p1 mb1 bg-darken-1 col-11"></div>
+          <div class="p1 mb1 bg-darken-1 col-8"></div>
+        </div>
+      </div>
+  <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,8 +6,12 @@
   <%= csrf_meta_tags %>
 </head>
 <body class="bg-darken-1">
-<div class="p2 bg-green white"><%= notice %></div>
-<div class="p2 bg-green white"><%= alert %></div>
+<%- unless notice.nil? %>
+  <div class="p2 bg-green white"><%= notice %></div>
+<%- end %>
+<%- unless alert.nil? %>
+  <div class="p2 bg-red white"><%= alert %></div>
+<%- end %>
 
 <%= yield %>
 

--- a/bin/cloud_deploy
+++ b/bin/cloud_deploy
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [ $# -ne 1 ]
+then
+	echo 'Usage: cloud_deploy [environment]'
+	exit 1
+fi
+
+if [ $1 != 'dev' -a $1 != 'demo' ]
+then
+	echo 'you must specify either dev or demo'
+	exit 1
+fi
+
+cf target -o consumer-identity -s $1
+echo setting up identity-sp-rails-$1
+cp manifest_$1.yml manifest.yml
+cf set-env identity-sp-rails-$1 SAML_ENV $1
+cf restage identity-sp-rails-$1
+cf push identity-sp-rails-$1
+rm manifest.yml

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -1,6 +1,7 @@
 postgresql: &postgresql
   adapter: postgresql
   encoding: utf8
+  database: id-sp-rails_<%= Rails.env %>
   port: 5432
 
 defaults: &defaults
@@ -12,12 +13,9 @@ defaults: &defaults
 
 development:
   <<: *defaults
-  database: id-sp-rails_<%= Rails.env %>
 
 test:
   <<: *defaults
-  database: id-sp-rails_<%= Rails.env %>
 
 production:
   <<: *defaults
-  database: id-sp-rails_production-<%= ENV['SAML_ENV'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,6 +42,9 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
+  # Enable stdout logger
+  config.logger = Logger.new(STDOUT)
+
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
   config.log_level = :debug

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,7 +1,6 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider(
     :saml,
-    assertion_consumer_service_url: 'http://localhost:3003/auth/saml/callback',
     assertion_consumer_service_binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
     issuer: Rails.application.secrets.saml_issuer,
     idp_sso_target_url: Rails.application.secrets.idp_url,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   root 'home#index'
   get 'success', to: 'home#success'
+  get 'failure', to: 'home#failure'
 
   post 'auth/:provider/callback', to: 'sessions#create'
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -22,5 +22,7 @@ test:
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-  saml_issuer: urn:gov:gsa:SAML:2.0.profiles:sp:sso:dev
-  idp_url: https://upaya-idp-dev.18f.gov/api/saml/auth
+  saml_issuer: urn:gov:gsa:SAML:2.0.profiles:sp:sso:rails-<%= ENV["SAML_ENV"] %>
+  idp_url: https://upaya-idp-<%= ENV["SAML_ENV"] %>.18f.gov/api/saml/auth
+  http_auth_username: <%= ENV["SP_NAME"] %>
+  http_auth_password: <%= ENV["SP_PASS"] %>

--- a/manifest_demo.yml
+++ b/manifest_demo.yml
@@ -1,0 +1,9 @@
+---
+applications:
+- name: identity-sp-rails-demo
+  memory: 256M
+  instances: 1
+  host: identity-sp-rails-demo
+  domain: apps.cloud.gov
+  services:
+  - id-sp-rails_production-demo

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -1,0 +1,9 @@
+---
+applications:
+- name: identity-sp-rails-dev
+  memory: 256M
+  instances: 1
+  host: identity-sp-rails-dev
+  domain: apps.cloud.gov
+  services:
+  - id-sp-rails_production-dev

--- a/spec/requests/omniauth_request_spec.rb
+++ b/spec/requests/omniauth_request_spec.rb
@@ -3,29 +3,29 @@ require 'omniauth_spec_helper'
 
 describe 'POST /auth/saml/callback' do
   context 'invalid credentials' do
-    it 'redirects to root with flash error' do
+    it 'redirects to failure with flash error' do
       OmniAuthSpecHelper.invalid_credentials
 
       OmniAuthSpecHelper.silence_omniauth do
         post '/auth/saml/callback'
       end
 
-      expect(response).to redirect_to root_url
-      expect(flash[:error]).
+      expect(response).to redirect_to failure_url
+      expect(flash[:alert]).
         to eq I18n.t('omniauth_callbacks.failure', reason: 'Invalid credentials')
     end
   end
 
   context 'invalid ticket' do
-    it 'redirects to root with flash error' do
+    it 'redirects to failure with flash error' do
       OmniAuthSpecHelper.invalid_ticket
 
       OmniAuthSpecHelper.silence_omniauth do
         post '/auth/saml/callback'
       end
 
-      expect(response).to redirect_to root_url
-      expect(flash[:error]).
+      expect(response).to redirect_to failure_url
+      expect(flash[:alert]).
         to eq I18n.t('omniauth_callbacks.failure', reason: 'Invalid ticket')
     end
   end

--- a/task_manifest.yml
+++ b/task_manifest.yml
@@ -1,0 +1,8 @@
+---
+applications:
+- name: task-runner
+  memory: 256M
+  services:
+  - id-sp-rails_production-demo
+  no-route: true
+  command: (rake db:setup && echo SUCCESS || echo FAIL) && sleep infinity


### PR DESCRIPTION
**Why:**
- All live sites need authentication.
- The app had old `issuer` info and no way of specifying -demo or -dev

**How:**
- Add authentication in production mode.
- Add one-line parameterized deployment script.