### PR TITLE
Make LOA configurable.

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -26,6 +26,12 @@ class SessionsController < ApplicationController
     redirect_to failure_url
   end
 
+  def setup
+    request.env['omniauth.strategy'].options[:authn_context] =
+      "http://idmanagement.gov/ns/assurance/loa/#{params[:loa]}" if params.key?(:loa)
+    render :text => "Omniauth setup phase.", :status => 404
+  end
+
   private
 
   def saml_settings

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -29,7 +29,7 @@ class SessionsController < ApplicationController
   def setup
     request.env['omniauth.strategy'].options[:authn_context] =
       "http://idmanagement.gov/ns/assurance/loa/#{params[:loa]}" if params.key?(:loa)
-    render :text => "Omniauth setup phase.", :status => 404
+    render text: 'Omniauth setup phase.', status: 404
   end
 
   private

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,7 +1,13 @@
-<div class="py1 mb3 center">
+<div class="py1 mb3 center" xmlns="http://www.w3.org/1999/html">
   <h2>Please log in to continue.</h2>
-  <%= link_to 'auth/saml' do %>
+  <%= form_tag('auth/saml', method: :get) do %>
+    <div>
       <button type="submit" class="btn btn-primary h3">login.gov →</button>
+    </div>
+    <%= label_tag 'loa_1', 'LOA 1' %>
+    <%= radio_button_tag 'loa', '1', true, class: "btn btn-primary h3" %>
+    <%= label_tag 'loa_3', 'LOA 3' %>
+    <%= radio_button_tag 'loa', '3', class: "btn btn-primary h3" %>
   <% end %>
 </div>
 <div class="clearfix py3 mxn1">

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -13,7 +13,8 @@ SAML_SETTINGS = {
               logout_requests_signed: true,
               embed_sign: true,
               digest_method: 'http://www.w3.org/2001/04/xmlenc#sha256',
-              signature_method: 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256' }
+              signature_method: 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256' },
+  setup: true
 }.freeze
 
 Rails.application.config.middleware.use OmniAuth::Builder do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
   post 'auth/:provider/callback', to: 'sessions#create'
   post 'auth/:provider/logout', to: 'sessions#destroy'
   delete 'auth/:provider/logout', to: 'sessions#destroy'
+  match 'auth/:provider/setup', to: 'sessions#setup', via: [:get, :post]
 end


### PR DESCRIPTION
**Why**:
- The LOA we request from the IDP should be configurable.

**How**:
- Add a `setup` phase to the SAML request.
- Add a radio button to the hope page to configure LOA. (note that we should probably have a more elegant way of specifying LOA)