### PR TITLE
Add explicit list of requested asserted attributes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,9 @@ gem 'turbolinks'
 
 gem 'omniauth-saml'
 
+# unreleased feature via: https://github.com/onelogin/ruby-saml/pull/345
+gem 'ruby-saml', git: 'https://github.com/onelogin/ruby-saml.git', branch: 'master'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/onelogin/ruby-saml.git
+  revision: 709b4c09a06ab7a299a512eaa166a56ddc50290a
+  branch: master
+  specs:
+    ruby-saml (1.3.1)
+      nokogiri (>= 1.5.10)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -155,8 +163,6 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
-    ruby-saml (1.3.0)
-      nokogiri (>= 1.5.10)
     safe_yaml (1.0.4)
     saml_idp (0.3.2)
       activesupport
@@ -222,6 +228,7 @@ DEPENDENCIES
   rails_12factor
   rspec-rails (~> 3.4)
   rubocop
+  ruby-saml!
   saml_idp
   sass-rails (~> 5.0)
   sinatra
@@ -229,6 +236,9 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
   webmock
+
+RUBY VERSION
+   ruby 2.3.1p112
 
 BUNDLED WITH
    1.12.5

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -27,8 +27,12 @@ class SessionsController < ApplicationController
   end
 
   def setup
-    request.env['omniauth.strategy'].options[:authn_context] =
-      "http://idmanagement.gov/ns/assurance/loa/#{params[:loa]}" if params.key?(:loa)
+    if params.key?(:loa)
+      request.env['omniauth.strategy'].options[:authn_context] = [
+        "http://idmanagement.gov/ns/assurance/loa/#{params[:loa]}",
+        'http://idmanagement.gov/ns/requested_attributes?ReqAttr=email,mobile,first_name,last_name,ssn'
+      ]
+    end
     render text: 'Omniauth setup phase.', status: 404
   end
 

--- a/spec/support/fake_saml_idp.rb
+++ b/spec/support/fake_saml_idp.rb
@@ -54,6 +54,8 @@ class FakeSamlIdp < Sinatra::Base
         email_address: -> (principal) { principal.email }
       }
 
+      # For now, we are ignoring AuthnContextClassRef and hardcoding the response's
+      # asserted attributes.
       config.attributes = {
         uid: {
           getter: :uid,


### PR DESCRIPTION
**Why**: The IdP app now requires an explicit attribute bundle. Since
we want both email and the verified (proved) attributes, we include
an explicit AuthnContextClassRef in our OmniAuth config.