### PR TITLE
Add tests for LOA3 authn context

### DIFF
--- a/.reek
+++ b/.reek
@@ -4,3 +4,5 @@ exclude_paths:
 
 IrresponsibleModule:
   enabled: false
+TooManyStatements:
+  max_statements: 6

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
   gem 'rspec-rails', '~> 3.4'
-  gem 'saml_idp'
+  gem 'saml_idp', '~> 0.4.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,8 +72,7 @@ GEM
       activesupport (>= 4.1.0)
     hashdiff (0.3.0)
     hashie (3.4.4)
-    httparty (0.13.7)
-      json (~> 1.8)
+    httparty (0.14.0)
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
     json (1.8.3)
@@ -164,7 +163,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
     safe_yaml (1.0.4)
-    saml_idp (0.3.2)
+    saml_idp (0.4.0)
       activesupport
       builder
       httparty
@@ -229,7 +228,7 @@ DEPENDENCIES
   rspec-rails (~> 3.4)
   rubocop
   ruby-saml!
-  saml_idp
+  saml_idp (~> 0.4.0)
   sass-rails (~> 5.0)
   sinatra
   turbolinks

--- a/app/services/user_with_asserted_attributes.rb
+++ b/app/services/user_with_asserted_attributes.rb
@@ -1,0 +1,18 @@
+class UserWithAssertedAttributes
+  def initialize(user)
+    @user = user
+  end
+
+  def call(attrs)
+    self.asserted_attributes = attrs
+  end
+
+  delegate :email, :uid, to: :user
+
+  attr_reader :asserted_attributes
+
+  private
+
+  attr_reader :user
+  attr_writer :asserted_attributes
+end

--- a/spec/requests/sso_spec.rb
+++ b/spec/requests/sso_spec.rb
@@ -1,19 +1,51 @@
 require 'rails_helper'
 
 describe 'SSO' do
-  it 'uses external SAML IdP' do
+  before do
     OmniAuth.config.test_mode = false
-    expect(User.count).to eq 0
+  end
 
-    get '/auth/saml'
-    expect(response).to redirect_to(%r{idp\.example\.com\/saml\/auth})
+  context 'LOA1' do
+    it 'uses external SAML IdP' do
+      expect(User.count).to eq 0
 
-    idp_uri = URI(response.headers['Location'])
-    saml_idp_resp = Net::HTTP.get(idp_uri)
+      get '/auth/saml'
+      expect(response).to redirect_to(%r{idp\.example\.com\/saml\/auth})
 
-    post '/auth/saml/callback', SAMLResponse: saml_idp_resp
+      idp_uri = URI(response.headers['Location'])
+      saml_idp_resp = Net::HTTP.get(idp_uri)
 
-    expect(response).to redirect_to('http://www.example.com/success')
-    expect(User.count).to eq 1
+      saml_response = OneLogin::RubySaml::Response.new(saml_idp_resp)
+      asserted_attributes = saml_response.attributes.attributes.keys.map(&:to_sym)
+      expect(asserted_attributes).to match_array([:uid, :email])
+
+      post '/auth/saml/callback', SAMLResponse: saml_idp_resp
+
+      expect(response).to redirect_to('http://www.example.com/success')
+      expect(User.count).to eq 1
+    end
+  end
+
+  context 'LOA3' do
+    it 'returns asserted attributes' do
+      expect(User.count).to eq 0
+
+      get '/auth/saml?loa=3'
+      expect(response).to redirect_to(%r{idp\.example\.com\/saml\/auth})
+
+      idp_uri = URI(response.headers['Location'])
+      saml_idp_resp = Net::HTTP.get(idp_uri)
+
+      saml_response = OneLogin::RubySaml::Response.new(saml_idp_resp)
+      asserted_attributes = saml_response.attributes.attributes.keys.map(&:to_sym)
+      expect(asserted_attributes).to match_array(
+        [:uid, :email, :mobile, :first_name, :last_name, :ssn]
+      )
+
+      post '/auth/saml/callback', SAMLResponse: saml_idp_resp
+
+      expect(response).to redirect_to('http://www.example.com/success')
+      expect(User.count).to eq 1
+    end
   end
 end


### PR DESCRIPTION
**Why**: IdP requires explicit attributes in request.

**How**: Add support to FakeSamlIdp server for dynamic
attributes following same pattern that identity-idp uses.