### PR TITLE
Add capistrano for deployments and target to login.gov 

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,0 +1,11 @@
+# Load DSL and Setup Up Stages
+require 'capistrano/setup'
+
+# Includes default deployment tasks
+require 'capistrano/deploy'
+
+# support for bundler, rails/assets and rails/migrations
+require 'capistrano/rails'
+
+# Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
+Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,11 @@ gem 'omniauth-saml'
 # unreleased feature via: https://github.com/onelogin/ruby-saml/pull/345
 gem 'ruby-saml', git: 'https://github.com/onelogin/ruby-saml.git', branch: 'master'
 
+group :deploy do
+  gem 'capistrano' # , '~> 3.4'
+  gem 'capistrano-rails' # , '~> 1.1', require: false
+end
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,12 +45,27 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
+    airbrussh (1.1.0)
+      sshkit (>= 1.6.1, != 1.7.0)
     arel (6.0.3)
     ast (2.3.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
     byebug (9.0.5)
+    capistrano (3.6.0)
+      airbrussh (>= 1.0.0)
+      capistrano-harrow
+      i18n
+      rake (>= 10.0.0)
+      sshkit (>= 1.9.0)
+    capistrano-bundler (1.1.4)
+      capistrano (~> 3.1)
+      sshkit (~> 1.2)
+    capistrano-harrow (0.5.3)
+    capistrano-rails (1.1.7)
+      capistrano (~> 3.1)
+      capistrano-bundler (~> 1.1)
     codeclimate-test-reporter (0.5.0)
       simplecov (>= 0.7.1, < 1.0.0)
     coffee-rails (4.1.1)
@@ -89,6 +104,9 @@ GEM
     mini_portile2 (2.1.0)
     minitest (5.9.0)
     multi_xml (0.5.5)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (3.2.0)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
@@ -193,6 +211,9 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sshkit (1.11.2)
+      net-scp (>= 1.1.2)
+      net-ssh (>= 2.8.0)
     systemu (2.6.5)
     thor (0.19.1)
     thread_safe (0.3.5)
@@ -221,6 +242,8 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  capistrano
+  capistrano-rails
   codeclimate-test-reporter
   omniauth-saml
   pg

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ May also function as reference Service Provider implementation.
 
     (see, for reference https://docs.cloud.gov/apps/databases/ and https://docs.cloud.gov/getting-started/one-off-tasks/)
 
+### Deploy to login.gov lower envs
+    $ cap [demo, dev, or tf] deploy
+    $ cap -T # for a list of available capistrano tasks
+
 ### Testing
 
     $ make test

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,11 +3,6 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  if Rails.env.production?
-    http_basic_authenticate_with name: Rails.application.secrets.http_auth_username,
-                                 password: Rails.application.secrets.http_auth_password
-  end
-
   helper_method :current_user
 
   def current_user

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,0 +1,29 @@
+#################
+# GLOBAL CONFIG
+#################
+set :application, 'sp-rails'
+# set branch based on env var or ask with the default set to the current local branch
+set :branch, ENV['branch'] || ENV['BRANCH'] || ask(:branch, `git branch`.match(/\* (\S+)\s/m)[1])
+set :bundle_without, 'deploy development doc test'
+set :deploy_to, '/srv/sp-rails'
+set :deploy_via, :remote_cache
+set :keep_releases, 5
+set :linked_files, %w(config/database.yml
+                      config/secrets.yml)
+set :linked_dirs, %w(bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system)
+set :rails_env, :production
+set :repo_url, 'https://github.com/18F/identity-sp-rails.git'
+set :ssh_options, forward_agent: false, user: 'ubuntu'
+set :tmp_dir, '/srv/sp-rails'
+
+#########
+# TASKS
+#########
+namespace :deploy do
+  desc 'Restart application'
+  task :restart do
+    on roles(:app), in: :sequence, wait: 5 do
+      execute :touch, release_path.join('tmp/restart.txt')
+    end
+  end
+end

--- a/config/deploy/demo.rb
+++ b/config/deploy/demo.rb
@@ -1,0 +1,1 @@
+server 'sp.demo.login.gov', roles: %w(web app db)

--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -1,0 +1,1 @@
+server 'sp.dev.login.gov', roles: %w(web app db)

--- a/config/deploy/tf.rb
+++ b/config/deploy/tf.rb
@@ -1,0 +1,1 @@
+server 'sp.tf.login.gov', roles: %w(web app db)


### PR DESCRIPTION
This adds support to deploy via capistrano to login.gov lower envs. It also removes the http basic auth config from the rails app since that is managed by nginx.