### PR TITLE
Add configurable LOA to agency mockups.

### DIFF
--- a/app/views/agency/ed/index.html.erb
+++ b/app/views/agency/ed/index.html.erb
@@ -24,6 +24,9 @@
       </div>
       <div class="sm-col-right">
         <form action="/auth/saml" method="GET" class="py2 px1">
+          <% if params[:loa] %>
+            <%= hidden_field_tag 'loa', params[:loa] %>
+          <% end %>
           <button type="submit" class="btn btn-outline bg-white navy">
             <%= image_tag 'login-gov.svg', class: "align-middle", width: "125" %>
           </button>

--- a/app/views/agency/irs/index.html.erb
+++ b/app/views/agency/irs/index.html.erb
@@ -17,13 +17,6 @@
     <% end %>
    </div>
   <% end %>
-  <div class="relative">
-    <%= image_tag 'irs/home.jpg' %>
-    <form action="/auth/saml" method="GET" class="absolute top-0 right-0 py2 px1">
-      <button type="submit" class="btn btn-outline bg-white navy">
-        <%= image_tag 'login-gov.svg', class: "align-middle", width: "125" %>
-      </button>
-    </form>
-  </div>
+  <%= render partial: 'shared/agency_form', locals: { image_url: 'irs/home.jpg' }  %>
 </body>
 </html>

--- a/app/views/agency/sba/index.html.erb
+++ b/app/views/agency/sba/index.html.erb
@@ -27,6 +27,9 @@
     <div class="border-top page-border p1 sm-show">
       <div class="right">
         <form action="/auth/saml" method="GET" class="">
+          <% if params[:loa] %>
+            <%= hidden_field_tag 'loa', params[:loa] %>
+          <% end %>
           <button type="submit" class="btn btn-outline bg-white navy">
             <%= image_tag "login-gov.svg", class: "align-middle", width: "125" %>
           </button>

--- a/app/views/agency/state/index.html.erb
+++ b/app/views/agency/state/index.html.erb
@@ -17,13 +17,6 @@
     <% end %>
    </div>
   <% end %>
-  <div class="relative">
-    <%= image_tag 'state/home.jpg' %>
-    <form action="/auth/saml" method="GET" class="absolute top-0 right-0 py2 px1">
-      <button type="submit" class="btn btn-outline bg-white navy">
-        <%= image_tag 'login-gov.svg', class: "align-middle", width: "125" %>
-      </button>
-    </form>
-  </div>
+  <%= render partial: 'shared/agency_form', locals: { image_url: 'state/home.jpg' }  %>
 </body>
 </html>

--- a/app/views/agency/treasury/index.html.erb
+++ b/app/views/agency/treasury/index.html.erb
@@ -17,13 +17,6 @@
     <% end %>
    </div>
   <% end %>
-  <div class="relative">
-    <%= image_tag 'treasury/home.jpg' %>
-    <form action="/auth/saml" method="GET" class="absolute top-0 right-0 py2 px1">
-      <button type="submit" class="btn btn-outline bg-white navy">
-        <%= image_tag 'login-gov.svg', class: "align-middle", width: "125" %>
-      </button>
-    </form>
-  </div>
+  <%= render partial: 'shared/agency_form', locals: { image_url: 'treasury/home.jpg' }  %>
 </body>
 </html>

--- a/app/views/agency/uscis/index.html.erb
+++ b/app/views/agency/uscis/index.html.erb
@@ -42,6 +42,9 @@
       </div>
       <div class="sm-col-right">
         <form action="/auth/saml" method="GET">
+          <% if params[:loa] %>
+            <%= hidden_field_tag 'loa', params[:loa] %>
+          <% end %>
           <button type="submit" class="btn btn-outline bg-white navy">
             <%= image_tag 'login-gov.svg', class: "align-middle", width:"125" %>
           </button>

--- a/app/views/shared/_agency_form.html.erb
+++ b/app/views/shared/_agency_form.html.erb
@@ -1,0 +1,11 @@
+<div class="relative">
+  <%= image_tag image_url %>
+  <form action="/auth/saml" method="GET" class="absolute top-0 right-0 py2 px1">
+    <% if params[:loa] %>
+      <%= hidden_field_tag 'loa', params[:loa] %>
+    <% end %>
+    <button type="submit" class="btn btn-outline bg-white navy">
+      <%= image_tag 'login-gov.svg', class: "align-middle", width: "125" %>
+    </button>
+  </form>
+</div>


### PR DESCRIPTION
**Why**:
- There's currently no way to go through the LOA3 flow from an agency.

**How**:
- Pass along a `loa` url param to a hidden field if present.
- Refactor half the agency pages that use an identical layout to use new `agency_form` partial.
- Do not try to refactor agencies that use non-standard layouts