### PR TITLE
Expect IDP will specify `phone` not mobile

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -30,7 +30,7 @@ class SessionsController < ApplicationController
     if params.key?(:loa)
       request.env['omniauth.strategy'].options[:authn_context] = [
         "http://idmanagement.gov/ns/assurance/loa/#{params[:loa]}",
-        'http://idmanagement.gov/ns/requested_attributes?ReqAttr=email,mobile,first_name,last_name,ssn'
+        'http://idmanagement.gov/ns/requested_attributes?ReqAttr=email,phone,first_name,last_name,ssn'
       ]
     end
     render text: 'Omniauth setup phase.', status: 404

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,6 @@ class User < ActiveRecord::Base
   def extra_attributes_from_auth(auth)
     extra_attrs = auth.extra.raw_info
     self.social_security_number = extra_attrs[:ssn]
-    self.phone = extra_attrs[:mobile]
+    self.phone = extra_attrs[:phone]
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe User, type: :model do
                                       extra: {
                                         raw_info: {
                                           ssn: '123456789',
-                                          mobile: '4155551212'
+                                          phone: '4155551212'
                                         }
                                       })
         user = nil
@@ -53,7 +53,7 @@ RSpec.describe User, type: :model do
                                       extra: {
                                         raw_info: {
                                           ssn: '123456789',
-                                          mobile: '4155551212'
+                                          phone: '4155551212'
                                         }
                                       })
         user = nil
@@ -61,7 +61,7 @@ RSpec.describe User, type: :model do
         expect(user.email).to eq(auth.info.email)
         expect(user.first_name).to eq(auth.info.first_name)
         expect(user.last_name).to eq(auth.info.last_name)
-        expect(user.phone).to eq(auth.extra.raw_info.mobile)
+        expect(user.phone).to eq(auth.extra.raw_info.phone)
         expect(user.social_security_number).to eq(auth.extra.raw_info.ssn)
       end
     end

--- a/spec/requests/sso_spec.rb
+++ b/spec/requests/sso_spec.rb
@@ -39,7 +39,7 @@ describe 'SSO' do
       saml_response = OneLogin::RubySaml::Response.new(saml_idp_resp)
       asserted_attributes = saml_response.attributes.attributes.keys.map(&:to_sym)
       expect(asserted_attributes).to match_array(
-        [:uid, :email, :mobile, :first_name, :last_name, :ssn]
+        [:uid, :email, :phone, :first_name, :last_name, :ssn]
       )
 
       post '/auth/saml/callback', SAMLResponse: saml_idp_resp


### PR DESCRIPTION
**Why**:
- IDP now has voice capability and will specify `phone` in the bundle, not `mobile`.

**How**:
- Change references to `mobile` in the bundle to `phone`.

Companion PR to `identity-idp` #375.