### PR TITLE
adding public domain to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,12 @@ May also function as reference Service Provider implementation.
 
     openssl req -newkey rsa:2048 -nodes -keyout config/server.key \
       -x509 -out config/server.crt -config config/openssl.conf
+
+
+## Public domain
+
+This project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](CONTRIBUTING.md):
+
+> This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+>
+> All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.


### PR DESCRIPTION
Currently the readme for this repo doesn't have the public domain section in the readme.  adding it with this pull request