### PR TITLE
Remove references to cloud.gov

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,34 +13,19 @@ May also function as reference Service Provider implementation.
 
     $ make setup
 
-### Setup (on cloud.gov)
-    $ cf target -o consumer-identity -s [dev or demo]
-    $ cf create-service rds shared-psql id-sp-rails_production-[dev or demo]
-    $ cf bind-service identity-sp-rails-[dev or demo] mid-sp-rails_production-[dev or demo]
-    $ cf restage identity-sp-rails-[dev or demo]
-
-    then
-    $ cf push -f task_manifest.yml (file needs to be edited for -dev)
-    $ cf delete task-runner
-
-    (see, for reference https://docs.cloud.gov/apps/databases/ and https://docs.cloud.gov/getting-started/one-off-tasks/)
-
 ### Deploy to login.gov lower envs
     $ cap [demo, dev, or tf] deploy
     $ cap -T # for a list of available capistrano tasks
 
 ### Testing
 
-    $ make test
+    $ make test  # rspec tests
+    $ make lint  # rubocop and reek
+    $ make check # everything
 
 ### Running
 
     $ SAML_ENV=local make run
-
-### Running (on cloud.gov)
-
-    $ bin/cloud_deploy [dev or demo]
-    (Note: You'll need to be logged into cloud.gov first)
 
 ### Generating a new key + self-signed cert
 


### PR DESCRIPTION
**Why**: Deployment is on par with our other identity apps.