### PR TITLE
Bundle update nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,9 +101,8 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (3.2.0)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
     omniauth (1.3.1)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
@@ -113,7 +112,6 @@ GEM
     parser (2.3.1.2)
       ast (~> 2.2)
     pg (0.18.4)
-    pkg-config (1.1.7)
     powerpack (0.1.1)
     rack (1.6.4)
     rack-protection (1.5.3)
@@ -260,4 +258,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.4
+   1.13.6


### PR DESCRIPTION
**Why**:
* Was getting this error on setup:

> Your bundle is locked to nokogiri (1.6.8), but that version could not be
  found in any of the sources listed in your Gemfile. If you haven't
  changed sources, that means the author of nokogiri (1.6.8) has removed
  it. You'll need to update your bundle to a different version of nokogiri
  (1.6.8) that hasn't been removed in order to install.