### PR TITLE
Write deploy.json file

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -18,3 +18,33 @@ set :rails_env, :production
 set :repo_url, 'https://github.com/18F/identity-sp-rails.git'
 set :ssh_options, forward_agent: false, user: 'ubuntu'
 set :tmp_dir, '/srv/sp-rails'
+
+#########
+# TASKS
+#########
+namespace :deploy do
+  desc 'Write deploy information to deploy.json'
+  task :deploy_json do
+    on roles(:web), in: :parallel do
+      require 'stringio'
+
+      within current_path do
+        deploy = {
+          env: fetch(:stage),
+          branch: fetch(:branch),
+          user: fetch(:local_user),
+          sha: fetch(:current_revision),
+          timestamp: fetch(:release_timestamp)
+        }
+
+        execute :mkdir, '-p', 'public/api'
+
+        # the #upload! method does not honor the values of #within at the moment
+        # https://github.com/capistrano/sshkit/blob/master/EXAMPLES.md#upload-a-file-from-a-stream
+        upload! StringIO.new(deploy.to_json), "#{current_path}/public/api/deploy.json"
+      end
+    end
+  end
+
+  after 'deploy:log_revision', :deploy_json
+end


### PR DESCRIPTION
**Why**:
so we can expose the status of this deploy in our dashboard

See: https://github.com/18F/identity-idp/pull/663, but avoiding CORS since current dashboard implementation is all server-side, no AJAX needed