### PR TITLE
Make deploy.json world-readable (#35)

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -43,6 +43,8 @@ namespace :deploy do
         # the #upload! method does not honor the values of #within at the moment
         # https://github.com/capistrano/sshkit/blob/master/EXAMPLES.md#upload-a-file-from-a-stream
         upload! StringIO.new(deploy.to_json), "#{current_path}/public/api/deploy.json"
+
+        execute :chmod, '+r', 'public/api/deploy.json'
       end
     end
   end


### PR DESCRIPTION
**Why**:
nginx runs processes as the "nobody" user so files need to be world-readable
in order to be served by nginx

(I think this is the last one of these for today)