### PR TITLE
Update paths used for FakeSamlIdp

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -20,8 +20,8 @@ development:
 test:
   secret_key_base: a5f920d926f83681b1ec629182cedcbae25f19ebca05801fe48d6de56ccc690fa998f2ec9db1486d3d084bf9a4afa9d78237ae5acd65aaf6d8177395943cc0ad
   saml_issuer: urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost-rails
-  idp_sso_url: http://idp.example.com/saml/auth
-  idp_slo_url: http://idp.example.com/saml/logout
+  idp_sso_url: http://idp.example.com/api/saml/auth
+  idp_slo_url: http://idp.example.com/api/saml/logout
   idp_cert_fingerprint: 'BD:21:A9:57:14:3C:A8:4F:3F:C5:E6:99:7F:97:F6:E4:7E:E7:1D:1F'
 
 # Do not keep production secrets in the repository,

--- a/spec/requests/slo_spec.rb
+++ b/spec/requests/slo_spec.rb
@@ -15,14 +15,14 @@ describe 'SLO' do
   describe 'IdP-initiated' do
     it 'uses external SAML IdP' do
       # ask the IdP to initiate a SLO
-      idp_uri = URI('http://idp.example.com/saml/logout')
+      idp_uri = URI('http://idp.example.com/api/saml/logout')
       saml_idp_resp = Net::HTTP.get(idp_uri)
 
       # send the SAMLRequest to our logout endpoint
       post '/auth/saml/logout', SAMLRequest: saml_idp_resp, RelayState: 'the_idp_session_id'
 
       # redirect to complete the sign-out at the IdP
-      expect(response).to redirect_to(%r{idp.example.com/saml/logout})
+      expect(response).to redirect_to(%r{idp.example.com/api/saml/logout})
     end
   end
 
@@ -34,7 +34,7 @@ describe 'SLO' do
       # ask the SP to initiate a SLO
       delete '/auth/saml/logout'
 
-      expect(response).to redirect_to(%r{idp.example.com/saml/logout})
+      expect(response).to redirect_to(%r{idp.example.com/api/saml/logout})
 
       # send the SAMLRequest to IdP
       idp_uri = URI(response.headers['Location'])

--- a/spec/requests/sso_spec.rb
+++ b/spec/requests/sso_spec.rb
@@ -10,7 +10,7 @@ describe 'SSO' do
       expect(User.count).to eq 0
 
       get '/auth/saml'
-      expect(response).to redirect_to(%r{idp\.example\.com\/saml\/auth})
+      expect(response).to redirect_to(%r{idp\.example\.com\/api\/saml\/auth})
 
       idp_uri = URI(response.headers['Location'])
       saml_idp_resp = Net::HTTP.get(idp_uri)
@@ -31,7 +31,7 @@ describe 'SSO' do
       expect(User.count).to eq 0
 
       get '/auth/saml?loa=3'
-      expect(response).to redirect_to(%r{idp\.example\.com\/saml\/auth})
+      expect(response).to redirect_to(%r{idp\.example\.com\/api\/saml\/auth})
 
       idp_uri = URI(response.headers['Location'])
       saml_idp_resp = Net::HTTP.get(idp_uri)

--- a/spec/support/fake_saml_idp.rb
+++ b/spec/support/fake_saml_idp.rb
@@ -7,13 +7,13 @@ class FakeSamlIdp < Sinatra::Base
 
   ASSERTED_ATTRIBUTES_URI_PATTERN = 'http://idmanagement.gov/ns/requested_attributes?ReqAttr='.freeze
 
-  get '/saml/auth' do
+  get '/api/saml/auth' do
     build_configs
     validate_saml_request
     encode_response(user)
   end
 
-  get '/saml/logout' do
+  get '/api/saml/logout' do
     build_configs
     if params[:SAMLRequest]
       validate_saml_request
@@ -48,8 +48,8 @@ class FakeSamlIdp < Sinatra::Base
       config.secret_key = File.read("#{Rails.root}/keys/saml_test_sp.key")
 
       config.base_saml_location = "#{idp_base_url}/saml"
-      config.single_service_post_location = "#{idp_base_url}/saml/auth"
-      config.single_logout_service_post_location = "#{idp_base_url}/saml/logout"
+      config.single_service_post_location = "#{idp_base_url}/api/saml/auth"
+      config.single_logout_service_post_location = "#{idp_base_url}/api/saml/logout"
 
       config.name_id.formats = {
         persistent: -> (principal) { principal.uid },


### PR DESCRIPTION
**Why**: These new routes reflect the actual path for the identity IDP
app.

See https://github.com/18F/micropurchase/pull/1499