### PR TITLE
Removes uniqueness constraint on email column

### DIFF
--- a/db/migrate/20170602194403_remove_index_on_emails_column.rb
+++ b/db/migrate/20170602194403_remove_index_on_emails_column.rb
@@ -1,0 +1,5 @@
+class RemoveIndexOnEmailsColumn < ActiveRecord::Migration
+  def change
+    remove_index :users, :email
+  end
+end

--- a/db/migrate/20170602194403_remove_index_on_emails_column.rb
+++ b/db/migrate/20170602194403_remove_index_on_emails_column.rb
@@ -1,5 +1,9 @@
 class RemoveIndexOnEmailsColumn < ActiveRecord::Migration
-  def change
+  def up
     remove_index :users, :email
+  end
+
+  def down
+    add_index :users, :email, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160801203346) do
+ActiveRecord::Schema.define(version: 20170602194403) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,7 +34,6 @@ ActiveRecord::Schema.define(version: 20160801203346) do
     t.string   "zip"
   end
 
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["social_security_number"], name: "index_users_on_social_security_number", using: :btree
 
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -20,6 +20,20 @@ describe SessionsController do
         expect(response).to redirect_to success_url
         expect(flash[:notice]).to eq I18n.t('omniauth_callbacks.success')
       end
+
+      context 'when an account already exists' do
+        before do
+          User.find_or_create_by(email: 'email@example.com')
+        end
+
+        it 'successfully authenticates the user' do
+          configure_valid_omniauth_login
+          post :create, provider: :saml
+
+          expect(session[:user_id]).to eq User.last.id
+          expect(response).to redirect_to success_url
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### Why
Sometimes authentication attempts produce a 500 error because of the uniqueness constraint on the Email column. In lower environments, this could be due to wiping out the IdP database or other manual interventions performed during debugging.


#### How
Drops the uniqueness constraint on the email column of the Users table