### PR TITLE
Remove web-console and add bummr

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,8 +30,6 @@ group :development, :test do
 end
 
 group :development do
-  # Access an IRB console on exception pages or by using <%= console %> in views
-  gem 'web-console', '~> 2.0'
   gem 'rubocop'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'bummr', require: false
   gem 'rubocop'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,9 @@ GEM
     arel (6.0.3)
     ast (2.3.0)
     builder (3.2.2)
+    bummr (0.2.0)
+      rainbow
+      thor
     byebug (9.0.5)
     capistrano (3.6.0)
       airbrussh (>= 1.0.0)
@@ -226,6 +229,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bummr
   byebug
   capistrano
   capistrano-passenger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,8 +53,6 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     arel (6.0.3)
     ast (2.3.0)
-    binding_of_caller (0.7.2)
-      debug_inspector (>= 0.0.1)
     builder (3.2.2)
     byebug (9.0.5)
     capistrano (3.6.0)
@@ -77,7 +75,6 @@ GEM
     concurrent-ruby (1.0.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
     erubis (2.7.0)
@@ -220,11 +217,6 @@ GEM
     unicode-display_width (1.1.0)
     uuid (2.3.8)
       macaddr (~> 1.0)
-    web-console (2.3.0)
-      activemodel (>= 4.0)
-      binding_of_caller (>= 0.7.2)
-      railties (>= 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
     webmock (2.1.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -251,11 +243,10 @@ DEPENDENCIES
   sinatra
   turbolinks
   uglifier (>= 1.3.0)
-  web-console (~> 2.0)
   webmock
 
 RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.6
+   1.14.6


### PR DESCRIPTION
**Why**: 
web-console can enable a DNS Rebinding attack. See: https://benmmurphy.github.io/blog/2016/07/11/rails-webconsole-dns-rebinding/

bummr is the gem we use in all identity-* repos for updating gems