### PR TITLE
Make basic auth more configurable

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
 
   helper_method :current_user
 
-  if Rails.env.production?
+  if (! Rails.application.secrets.http_auth_username.nil?) && (! Rails.application.secrets.http_auth_password.nil?)
     http_basic_authenticate_with(
       name: Rails.application.secrets.http_auth_username,
       password: Rails.application.secrets.http_auth_password

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,8 @@ class ApplicationController < ActionController::Base
 
   helper_method :current_user
 
-  if (! Rails.application.secrets.http_auth_username.nil?) && (! Rails.application.secrets.http_auth_password.nil?)
+  if !Rails.application.secrets.http_auth_username.nil? &&
+     !Rails.application.secrets.http_auth_password.nil?
     http_basic_authenticate_with(
       name: Rails.application.secrets.http_auth_username,
       password: Rails.application.secrets.http_auth_password


### PR DESCRIPTION
__Why__

* We need to be able to turn the basic auth config on/off with the secrets.yml

__How__

* Make it so that we test whether the username/pw exists rather than keying off of production/nonprod