### PR TITLE
Inform reader of local idp dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Mock service provider (SP) app for validating IdP and IdV APIs.
 
 May also function as reference Service Provider implementation.
 
+These instructions assume [`identity-idp`](https://github.com/18F/identity-idp) is also running locally at `http://localhost:3000`. This sample sp is configured to run on `http://localhost:3003`.
+
 ### Setup
 
     $ make setup


### PR DESCRIPTION
I think this additional README information would improve the developer experience. When I first tried to run the app, I didn't know I should also be running idp locally. So there was a period of time I was running into errors without knowing why, until I saw this guidance in another one of the example sp repos. Then it all made sense. 😄 